### PR TITLE
Disable Vagrant guest tools update

### DIFF
--- a/vm/Vagrantfile
+++ b/vm/Vagrantfile
@@ -15,7 +15,7 @@ Vagrant.configure("2") do |config|
   # config.vm.synced_folder "../data", "/vagrant_data"
   config.vm.provider :parallels do |p, override|
     p.name = "gitlab"
-    p.update_guest_tools = true
+    p.update_guest_tools = false
     p.optimize_power_consumption = false
     p.memory = 2048
     p.cpus = 2
@@ -30,6 +30,9 @@ Vagrant.configure("2") do |config|
     vb.name = "gitlab"
     vb.customize ["modifyvm", :id, "--memory", "1024"]
     vb.customize ["modifyvm", :id, "--cpus", "2"]
+    if Vagrant.has_plugin?("vagrant-vbguest")
+      config.vbguest.auto_update = false
+    end
   end
 
   config.vm.provision :shell, :path => ".provisioner/setup_gitlab.sh"


### PR DESCRIPTION
This is known to cause trouble, and we won't use shared folders
anyways later on.