### PR TITLE
Small Wizard fixes

### DIFF
--- a/global/wizard.sh
+++ b/global/wizard.sh
@@ -51,7 +51,7 @@ printsolutions () {
 }
 
 setlayout () {
-  find . -type l -name *.css -maxdepth 1 -delete
+  find . -maxdepth 1 -type l -name *.css -delete
   ln -s global/layouts/$1.css .
 }
 

--- a/global/wizard.sh
+++ b/global/wizard.sh
@@ -93,13 +93,13 @@ done
 
 case "$LAYOUT" in
   1) LAYOUT=netways
-     sed -i '' 's|^[ \t\s]*"default":.*|    "default": "global/layouts/netways.tpl"|' showoff.json;;
+     sed -i 's|^[ \t\s]*"default":.*|    "default": "global/layouts/netways.tpl"|' showoff.json;;
   2) LAYOUT=osmc
-     sed -i '' 's|^[ \t\s]*"default":.*|    "default": "global/layouts/osmc.tpl"|' showoff.json;;
+     sed -i 's|^[ \t\s]*"default":.*|    "default": "global/layouts/osmc.tpl"|' showoff.json;;
   3) LAYOUT=osdc
-     sed -i '' 's|^[ \t\s]*"default":.*|    "default": "global/layouts/osdc.tpl"|' showoff.json;;
+     sed -i 's|^[ \t\s]*"default":.*|    "default": "global/layouts/osdc.tpl"|' showoff.json;;
   4) LAYOUT=osbconf
-     sed -i '' 's|^[ \t\s]*"default":.*|    "default": "global/layouts/osbconf.tpl"|' showoff.json;;
+     sed -i 's|^[ \t\s]*"default":.*|    "default": "global/layouts/osbconf.tpl"|' showoff.json;;
 esac
 
 setlayout $LAYOUT

--- a/showoff.json
+++ b/showoff.json
@@ -12,7 +12,7 @@
   "password": "awesome",
 
   "templates" : {
-       "default"   : "global/layouts/netways.tpl"
+       "default": "global/layouts/netways.tpl"
   },
 
   "sections": [


### PR DESCRIPTION
This fixes a few small issues with the wizard. Previously:
```
sed: can't read s|^[ \t\s]*"default":.*|    "default": "global/layouts/netways.tpl"|: No such file or directory
find: warning: you have specified the -maxdepth option after a non-option argument -type, but options are not positional (-maxdepth affects tests specified before it as well as those specified after it).  Please specify options before other arguments.
```

The find is just a warning, reordering the arguments fixes this. The sed is different, it may be dependent on implementation but the current one does simply not work on my machine. The third commit removes some whitespaces so the regex matches.