### PR TITLE
Remove CSS from the instructions

### DIFF
--- a/day2/04_Gitlab_Hints/03_Administration.md
+++ b/day2/04_Gitlab_Hints/03_Administration.md
@@ -25,7 +25,6 @@ Navigate to `Admin > Appearance`.
 * Custom header logo
 * Login page text
 * New project guidelines
-* Custom Themes
 
 ~~~SECTION:handouts~~~
 

--- a/day2/04_Gitlab_Hints/03_Administration.md
+++ b/day2/04_Gitlab_Hints/03_Administration.md
@@ -25,13 +25,12 @@ Navigate to `Admin > Appearance`.
 * Custom header logo
 * Login page text
 * New project guidelines
-* Custom Themes (SASS, CSS)
+* Custom Themes
 
 ~~~SECTION:handouts~~~
 
 ****
 
-More details for custom themes: https://gitlab.com/gitlab-org/end-user-training-slides/blob/master/css/theme/README.md
 
 ~~~ENDSECTION~~~
 


### PR DESCRIPTION
Removes the hint for CSS from the customization slide

fixes #88 