### PR TITLE
Update ssh-keygen example to use ed25519

### DIFF
--- a/day1/06_Server/04_Connect_Local_Remote.md
+++ b/day1/06_Server/04_Connect_Local_Remote.md
@@ -39,13 +39,13 @@ in GitLab.
 Generate a new SSH key pair on your client.
 
 ```
-ssh-keygen
+ssh-keygen -t ed25519
 ```
 
 Copy the public key into your GitLab settings.
 
 ```
-cat $HOME/.ssh/id_rsa.pub
+cat $HOME/.ssh/id_ed25519.pub
 ```
 
 User > Settings > SSH Keys


### PR DESCRIPTION
 - Not all ssh-keygen versions might have a secure default
 - See https://docs.gitlab.com/ee/user/ssh.html

Personally, I'd recommend ed25519...