### PR TITLE
Change Container Image references to be full-qualified

### DIFF
--- a/day2/03_CI/03_Gitlab_CI.md
+++ b/day2/03_CI/03_Gitlab_CI.md
@@ -211,7 +211,7 @@ Registered runners are listed at the bottom.
  * Paste the token
  * Add description `training01` and tag `training`
  * Untagged builds: `true`, Lock to current project: `false`
- * Executor: `docker`, Default: `alpine:latest`
+ * Executor: `docker`, Default: `docker.io/alpine:latest`
 
 
 Reference: https://gitlab.com/gitlab-org/gitlab-runner/blob/master/docs/install/linux-repository.md
@@ -274,7 +274,7 @@ Start CLI
     docker
 
     Please enter the default Docker image (e.g. ruby:2.1):
-    alpine:latest
+    docker.io/alpine:latest
 
     Runner registered successfully. Feel free to start it, but if it's running already the config should be automatically reloaded!
 
@@ -288,7 +288,7 @@ Start CLI
 
 Example:
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     all_tests:
       script:
@@ -312,7 +312,7 @@ https://about.gitlab.com/2016/03/01/gitlab-runner-with-docker/
  * Create CI configuration for the training project
 * Steps:
  * Create the `.gitlab-ci.yml` file in the `training` directory (vim, nano, etc.)
- * Add `image: alpine:latest` to specify base image
+ * Add `image: docker.io/alpine:latest` to specify base image
  * Add job `all_tests` with `script` as array element, which itself runs `exit 1`
 
 
@@ -334,7 +334,7 @@ https://about.gitlab.com/2016/03/01/gitlab-runner-with-docker/
 ## Steps:
 
 * Create the `.gitlab-ci.yml` file in the `training` directory (vim, nano, etc.)
-* Add `image: alpine:latest` to specify base image
+* Add `image: docker.io/alpine:latest` to specify base image
 * Add job `all_tests` with `script` as array element, which itself runs `exit 1`
 
 !SLIDE supplemental solutions
@@ -351,7 +351,7 @@ https://about.gitlab.com/2016/03/01/gitlab-runner-with-docker/
     $ cd $HOME/training
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     all_tests:
       script:
@@ -417,7 +417,7 @@ Future examples and tests work the same way.
     @@@ Sh
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     all_tests:
       script:
@@ -498,7 +498,7 @@ Example:
     @@@ Sh
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     before_script:
 
@@ -507,7 +507,7 @@ Example:
     @@@ Sh
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     before_script:
       - apk update && apk add python3 py-pip
@@ -517,7 +517,7 @@ Example:
     @@@ Sh
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     before_script:
       - apk update && apk add python3 py-pip
@@ -528,7 +528,7 @@ Example:
     @@@ Sh
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     before_script:
       - apk update && apk add python3 py-pip
@@ -642,7 +642,7 @@ Tell GitLab to expire this artifact in `1 week`.
     @@@ Sh
     $ vim .gitlab-ci.yml
 
-    image: alpine:latest
+    image: docker.io/alpine:latest
 
     before_script:
       - apk update && apk add python3 py-pip


### PR DESCRIPTION
 - The Docker Runtime hides the fact, that Images should be full-qualified. Other Runtime require it (Podman for example)

Also, the GitLab Registry also requires a FQ Image Name.