### PR TITLE
Rename SHA-1 to just SHA

### DIFF
--- a/day1/01_Introduction/03_Basics.md
+++ b/day1/01_Introduction/03_Basics.md
@@ -46,7 +46,7 @@
 !SLIDE smbullets
 # Integrity
 
-* Everything has a checksum (SHA-1)
+* Everything has a checksum (SHA)
 * No changes possible without Git knowing about them
 * Checksums are used everywhere
 * Revert changes and even restore deleted files

--- a/day1/05_Branching/02_head_smart_pointers.md
+++ b/day1/05_Branching/02_head_smart_pointers.md
@@ -1,7 +1,7 @@
 !SLIDE smbullets
 # HEAD and "smart pointers"
 
-A git commit is unique and identified by its SHA1 checksum.
+A git commit is unique and identified by its SHA checksum.
 
 `HEAD` is a pointer to the latest commit in the current branch.
 


### PR DESCRIPTION
 - This way we don't care what's the current implementation. No future changes required
 - git's current SHA implementation can be mentioned in the live training

Fixes #115 