### PR TITLE
Replace instances of git reset with git rm --cached

### DIFF
--- a/day1/03_Basics/01_Intro.md
+++ b/day1/03_Basics/01_Intro.md
@@ -5,7 +5,7 @@
 # Git Command Overview
 
 * Start a working area (clone, init)
-* Work on current changes (add, reset)
+* Work on current changes (add, rm)
 * Examine the history and state (status, log)
 * Grow, mark and tweak the history (branch, checkout, commit, merge, rebase)
 * Collaborate (fetch, pull, push)
@@ -21,10 +21,10 @@ Example from Git CLI command:
        init       Create an empty Git repository or reinitialize an existing one
     
     work on the current change (see also: git help everyday)
-       add        Add file contents to the index
-       mv         Move or rename a file, a directory, or a symlink
-       reset      Reset current HEAD to the specified state
-       rm         Remove files from the working tree and from the index
+       add         Add file contents to the index
+       mv          Move or rename a file, a directory, or a symlink
+       rm --cached Reset current HEAD to the specified state
+       rm          Remove files from the working tree and from the index
     
     examine the history and state (see also: git help revisions)
        bisect     Use binary search to find the commit that introduced a bug

--- a/day1/03_Basics/03_Changes.md
+++ b/day1/03_Basics/03_Changes.md
@@ -17,7 +17,7 @@ waiting for the commit. This applies to both, new files and also modified
 files.
 
 If you're using `-A` to add all files, you need to ensure that
-unwanted files are not added. Learn more about `git reset` in the next
+unwanted files are not added. Learn more about `git rm --cached` in the next
 slide to selectively unstage added changes.
 
 `git mv` renames an existing file tracking the change for the commit. If you
@@ -90,20 +90,18 @@ in the `README.md` file.
 !SLIDE smbullets
 # Remove changes
 
-* `git reset`
+* `git rm --cached`
   * Reset files added to the staging index
   * Hint: This comes in handy with `git add -A` before
 * `git rm`
   * Remove the file(s) from working tree and Git repository
   * Note that file(s) will be visible in Git history, and can be restored from it
-* `git rm --cached`
-  * Alternative suggested by Git CLI for `git reset`
 
 ~~~SECTION:handouts~~~
 
 ****
 
-`git reset` resets files added to the staging index. You can also use it to
+`git rm --cached` resets files added to the staging index. You can also use it to
 reset commits from the history.
 
 This also is helpful when you need to add 95 out of 100 changes. First, use `git add -A`
@@ -122,7 +120,7 @@ and then selectively unstage the unwanted 5 changes.
  * Reset file from staging index
 * Steps:
  * Change into `$HOME/training`
- * Remove the previously added `README.md` file from the staging index with `git reset README.md`
+ * Remove the previously added `README.md` file from the staging index with `git rm --cached README.md`
  * Verify it with `git status` and explain what happened
  * Re-add the `README.md` and examine again with `git status`
 
@@ -146,7 +144,7 @@ and then selectively unstage the unwanted 5 changes.
 ****
 
 * Change into `$HOME/training`
-* Remove the previously added `README.md` file from the staging index with `git reset README.md`
+* Remove the previously added `README.md` file from the staging index with `git rm --cached README.md`
 * Verify it with `git status` and explain what happened
 * Re-add the `README.md` and examine again with `git status`
 
@@ -165,7 +163,7 @@ and then selectively unstage the unwanted 5 changes.
 
     $ git status
 
-    $ git reset README.md
+    $ git rm --cached README.md
 
     $ git status
 

--- a/static/index.html
+++ b/static/index.html
@@ -1144,7 +1144,7 @@ email = michael.friedrich@netways.de</code></pre>
 
 <ul>
 <li>Start a working area (clone, init)</li>
-<li>Work on current changes (add, reset)</li>
+<li>Work on current changes (add, rm)</li>
 <li>Examine the history and state (status, log)</li>
 <li>Grow, mark and tweak the history (branch, checkout, commit, merge, rebase)</li>
 <li>Collaborate (fetch, pull, push)</li>
@@ -1168,10 +1168,10 @@ email = michael.friedrich@netways.de</code></pre>
    init       Create an empty Git repository or reinitialize an existing one
 
 work on the current change (see also: git help everyday)
-   add        Add file contents to the index
-   mv         Move or rename a file, a directory, or a symlink
-   reset      Reset current HEAD to the specified state
-   rm         Remove files from the working tree and from the index
+   add         Add file contents to the index
+   mv          Move or rename a file, a directory, or a symlink
+   rm --cached Reset current HEAD to the specified state
+   rm          Remove files from the working tree and from the index
 
 examine the history and state (see also: git help revisions)
    bisect     Use binary search to find the commit that introduced a bug
@@ -1379,7 +1379,7 @@ waiting for the commit. This applies to both, new files and also modified
 files.</p>
 
 <p>If you're using <code>-A</code> to add all files, you need to ensure that
-unwanted files are not added. Learn more about <code>git reset</code> in the next
+unwanted files are not added. Learn more about <code>git rm --cached</code> in the next
 slide to selectively unstage added changes.</p>
 
 <p><code>git mv</code> renames an existing file tracking the change for the commit. If you
@@ -1453,7 +1453,7 @@ in the <code>README.md</code> file.</p>
 
 <ul>
 <li>
-<code>git reset</code>
+<code>git rm --cached</code>
 
 <ul>
 <li>Reset files added to the staging index.</li>
@@ -1468,15 +1468,6 @@ in the <code>README.md</code> file.</p>
 <li>Note that file(s) will be visible in Git history, and can be restored from it.</li>
 </ul>
 </li>
-<li>
-<code>git rm --cached</code>
-
-<ul>
-<li>Alternative suggested by Git CLI for <code>git reset</code>
-</li>
-</ul>
-</li>
-</ul>
 
 
 
@@ -1489,7 +1480,7 @@ in the <code>README.md</code> file.</p>
 
 <hr>
 
-<p><code>git reset</code> resets files added to the staging index. You can also use it to
+<p><code>git rm --cached</code> resets files added to the staging index. You can also use it to
 reset commits from the history.</p>
 
 <p>This also is helpful when you need to add 95 out of 100 changes. First, use <code>git add -A</code>
@@ -1521,7 +1512,7 @@ and then selectively unstage the unwanted 5 changes.</p>
 <ul>
 <li>Change into <code>$HOME/training</code>
 </li>
-<li>Remove the previously added <code>README.md</code> file from the staging index with <code>git reset README.md</code>
+<li>Remove the previously added <code>README.md</code> file from the staging index with <code>git rm --cached README.md</code>
 </li>
 <li>Verify it with <code>git status</code> and explain what happened.</li>
 <li>Re-add the <code>README.md</code> and examine again with <code>git status</code>.</li>


### PR DESCRIPTION
fixes #151 

We should discuss day1/05_Branching/03_Reset_Commit.md though, `git rm --cached` doesn't entirely replace `git reset --hard` or `git reset --soft`.