### PR TITLE
Update SVN slide and move three stages and snapshots closer together

### DIFF
--- a/day1/01_Introduction/03_Basics.md
+++ b/day1/01_Introduction/03_Basics.md
@@ -1,9 +1,9 @@
 !SLIDE smbullets
-# Git Basics
+# When coming from another VCS
 
-* Learn Git, forget about other VCS systems (SVN, etc.)
-* Git interface is similar to existing VCS
-* ... but Git behaves differently
+* If you have knowledge about other VCS - try to put it aside
+* A lot of commands sound similar but work differently in git
+  * A `git commit` is not the same as an `svn commit`
 
 ~~~SECTION:handouts~~~
 

--- a/day1/01_Introduction/03_Basics.md
+++ b/day1/01_Introduction/03_Basics.md
@@ -34,34 +34,6 @@
 <center><img src="../../_images/mermaid/deltas.mmd.png" width="70%" alt="Detla Changes"/></center>
 
 
-!SLIDE smbullets
-# Work locally
-
-* No network latency involved as with other VCS systems
-* Local repository clone, fast operations
- * Browse the history
- * Show differences between specific branches
-* Work offline and push changes later
-
-!SLIDE smbullets
-# Integrity
-
-* Everything has a checksum (SHA)
-* No changes possible without Git knowing about them
-* Checksums are used everywhere
-* Revert changes and even restore deleted files
-
-Example:
-
-    7f0b824ba55e1fd4ffc5c461df0a0f48a94195cc
-
-~~~SECTION:handouts~~~
-
-****
-
-
-~~~ENDSECTION~~~
-
 !SLIDE smbullets noprint
 # The three states
 
@@ -155,3 +127,31 @@ is copied when you clone a repository from another computer.
 
 ~~~ENDSECTION~~~
 
+
+!SLIDE smbullets
+# The Git Workfow is local
+
+* No network latency involved as with other VCS systems
+* Local repository clone, fast operations
+ * Browse the history
+ * Show differences between specific branches
+* Work offline and push changes later
+
+!SLIDE smbullets
+# Git Object Integrity
+
+* Everything has a checksum (SHA)
+* No changes possible without Git knowing about them
+* Checksums are used everywhere
+* Revert changes and even restore deleted files
+
+Example:
+
+    7f0b824ba55e1fd4ffc5c461df0a0f48a94195cc
+
+~~~SECTION:handouts~~~
+
+****
+
+
+~~~ENDSECTION~~~


### PR DESCRIPTION
* Moved the three git stages and the snapshot slides closer together
  * These two concept belong together and the other two slides created context switching

* Reworked SVN slide to reflect its meaning more clearly

Fixes #206 
Fixes #204 