### PR TITLE
Fix pip install demos

### DIFF
--- a/day2/03_CI/03_Gitlab_CI.md
+++ b/day2/03_CI/03_Gitlab_CI.md
@@ -314,7 +314,7 @@ Example:
 
     before_script:
       - apk update && apk add python3 py-pip
-      - pip install markdown Pygments pymarkdownlnt
+      - pip install --break-system-packages markdown Pygments pymarkdownlnt
 
 ~~~SECTION:handouts~~~
 
@@ -357,7 +357,7 @@ Example:
 
     before_script:
       - apk update && apk add python3 py-pip
-      - pip install markdown Pygments pymarkdownlnt
+      - pip install --break-system-packages markdown Pygments pymarkdownlnt
 
 !SLIDE supplemental solutions
 # Lab ~~~SECTION:MAJOR~~~.~~~SECTION:MINOR~~~: Proposed Solution
@@ -392,7 +392,7 @@ Example:
 
     before_script:
       - apk update && apk add python3 py-pip
-      - pip install markdown Pygments pymarkdownlnt
+      - pip install --break-system-packages markdown Pygments pymarkdownlnt
 
 ### Verify the content
 
@@ -402,7 +402,7 @@ Example:
 
     before_script:
       - apk update && apk add python3 py-pip
-      - pip install markdown Pygments pymarkdownlnt
+      - pip install --break-system-packages markdown Pygments pymarkdownlnt
 
     all_tests:
       script:
@@ -562,7 +562,7 @@ Tell GitLab to expire this artifact in `1 week`.
 
     before_script:
       - apk update && apk add python3 py-pip
-      - pip install markdown Pygments pymarkdownlnt
+      - pip install --break-system-packages markdown Pygments pymarkdownlnt
 
     all_tests:
       script:

--- a/day2/03_CI/04_Gitlab_Pipelines.md
+++ b/day2/03_CI/04_Gitlab_Pipelines.md
@@ -121,7 +121,7 @@ Documentation: https://docs.gitlab.com/ce/ci/yaml/README.html#stage
 
     before_script:
       - apk update && apk add python py-pip
-      - pip install markdown Pygments pymarkdownlnt
+      - pip install --break-system-packages markdown Pygments pymarkdownlnt
 
     stages:
       - test


### PR DESCRIPTION
 - pip now requires a venv so it doesn't break the system packages. This great, but we are fine in the Containers and the labs
 - See https://peps.python.org/pep-0668/

Fixes #244 